### PR TITLE
move to RTCM flag instead of bypass

### DIFF
--- a/octoprint_latheengraver/_bgs.py
+++ b/octoprint_latheengraver/_bgs.py
@@ -270,6 +270,7 @@ def on_event(_plugin, event, payload):
 
         _plugin.fluidConfig = None
         _plugin._printer.commands(["$I", "$G"])
+        _plugin.RTCM = False
         # _plugin._printer.fake_ack()
 
     # Disconnecting & Disconnected
@@ -294,7 +295,7 @@ def on_event(_plugin, event, payload):
         _plugin.queue_B = _plugin.grblB
         _plugin.queue_S = 0.0
         _plugin.queue_F = 0.0
-        _plugin.bypass_queuing = False
+        _plugin.RTCM = False
         return
 
     # 'PrintStarted'
@@ -351,7 +352,7 @@ def on_event(_plugin, event, payload):
         _plugin.queue_Z = _plugin.grblZ
         _plugin.queue_A = _plugin.grblA
         _plugin.queue_B = _plugin.grblB
-        _plugin.bypass_queuing = False
+        _plugin.RTCM = False
         _plugin._printer.fake_ack()
         return
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_latheengraver"
 plugin_name = "LatheEngraver Support"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.14"
+plugin_version = "1.0.15"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Rather than have the Real-time coordinate modifications (RTCM) happen by default and then bypass, it is now repressed by default and activated by sending `RTCM`. This will automatically be turned in if `DOBANGLE` is sent as well.